### PR TITLE
use child_process directly

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -1,8 +1,7 @@
 'use strict';
 const path = require('path');
-const childProcess = require('child_process');
 const pify = require('pify');
-const cp = pify(childProcess);
+const cp = pify(child_process);
 
 const appsList = [
 	{

--- a/lib/osx.js
+++ b/lib/osx.js
@@ -1,8 +1,7 @@
 'use strict';
 const path = require('path');
-const childProcess = require('child_process');
 const pify = require('pify');
-const execFile = pify(childProcess.execFile);
+const execFile = pify(child_process.execFile);
 const bin = path.join(__dirname, 'osx-wallpaper');
 
 exports.get = () => execFile(bin).then(x => x.trim());

--- a/lib/win.js
+++ b/lib/win.js
@@ -1,8 +1,7 @@
 'use strict';
 const path = require('path');
-const childProcess = require('child_process');
 const pify = require('pify');
-const execFile = pify(childProcess.execFile);
+const execFile = pify(child_process.execFile);
 const bin = path.join(__dirname, 'win-wallpaper.exe');
 
 exports.get = () => execFile(bin).then(x => x.trim());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wallpaper",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Get or set the desktop wallpaper",
   "license": "MIT",
   "repository": "sindresorhus/wallpaper",


### PR DESCRIPTION
I am unable to use this module with webpack without this change. I'm creating an electron application if you're wondering why I'm trying to webpack up something with child_process.

I'm not sure exactly if this function is ever not directly available, however - do you know?