### PR TITLE
windows shell with forever

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -11,12 +11,14 @@ const fs = pify(fileSystem);
 const appsList = [
 	{
 		cmd: 'gsettings',
-		set: ['set',
+		set: [
+			'set',
 			'org.gnome.desktop.background',
 			'picture-uri',
 			'file://%s'
 		],
-		get: ['get',
+		get: [
+			'get',
 			'org.gnome.desktop.background',
 			'picture-uri'
 		],
@@ -67,7 +69,8 @@ const appsList = [
 		cmd: 'dconf',
 		set: ['write',
 			'/org/mate/desktop/background/picture-filename',
-			'"%s"'],
+			'"%s"'
+		],
 		get: ['read',
 			'/org/mate/desktop/background/picture-filename'
 		],
@@ -122,6 +125,14 @@ function isCinnamon() {
 		.catch(() => {});
 }
 
+function isMATE() {
+	const args = ['writable', 'org.mate.background', 'picture-filename'];
+
+	return cp.execFile('gsettings', args)
+		.then(out => out.trim() === 'true')
+		.catch(() => {});
+}
+
 exports.get = function get() {
 	if (!availableApps) {
 		return setAvailableApps().then(get);
@@ -137,20 +148,28 @@ exports.get = function get() {
 	}
 
 	if (app.cmd === 'gsettings') {
-		return isCinnamon().then(cinnamon => {
-			const getArgs = app.get.slice();
+		const getArgs = app.get.slice();
+		return isCinnamon()
+		.then(cinnamon => {
 			if (cinnamon) {
 				getArgs[1] = 'org.cinnamon.desktop.background';
 			}
-			return cp.execFile(app.cmd, getArgs).then(stdout => {
-				stdout = stdout.trim();
+		})
+		.then(() => isMATE())
+		.then(mate => {
+			if (mate) {
+				getArgs.splice(1, 2, 'org.mate.background', 'picture-filename');
+			}
+		})
+		.then(() => cp.execFile(app.cmd, getArgs))
+		.then(stdout => {
+			stdout = stdout.trim();
 
-				if (typeof app.transform === 'function') {
-					return app.transform(stdout);
-				}
+			if (typeof app.transform === 'function') {
+				return app.transform(stdout);
+			}
 
-				return stdout;
-			});
+			return stdout;
 		});
 	}
 
@@ -180,12 +199,19 @@ exports.set = function set(imagePath) {
 	params[params.length - 1] = params[params.length - 1].replace('%s', path.resolve(imagePath));
 
 	if (app.cmd === 'gsettings') {
-		return isCinnamon().then(cinnamon => {
+		return isCinnamon()
+		.then(cinnamon => {
 			if (cinnamon) {
 				params[1] = 'org.cinnamon.desktop.background';
 			}
-			return cp.execFile(app.cmd, params);
-		});
+		})
+		.then(() => isMATE())
+		.then(mate => {
+			if (mate) {
+				params.splice(1, 3, 'org.mate.background', 'picture-filename', params[3].replace(/^file:\/\//, ''));
+			}
+		})
+		.then(() => cp.execFile(app.cmd, params));
 	}
 
 	return cp.execFile(app.cmd, params);

--- a/lib/win.js
+++ b/lib/win.js
@@ -17,7 +17,7 @@ exports.set = imagePath => {
 	}
 
 	return new Promise((resolve, reject) => {
-		let proc = spawn(bin, [path.resolve(imagePath)], {
+		const proc = spawn(bin, [path.resolve(imagePath)], {
 			detached: true,
 			shell: false
 		});

--- a/lib/win.js
+++ b/lib/win.js
@@ -3,6 +3,7 @@ const path = require('path');
 const childProcess = require('child_process');
 const pify = require('pify');
 
+const spawn = childProcess.spawn;
 const execFile = pify(childProcess.execFile);
 
 // Binary source → https://github.com/sindresorhus/win-wallpaper
@@ -15,5 +16,21 @@ exports.set = imagePath => {
 		return Promise.reject(new TypeError('Expected a string'));
 	}
 
-	return execFile(bin, [path.resolve(imagePath)]);
+  return new Promise((resolve, reject) => {
+    var proc = spawn(bin, [path.resolve(imagePath)], {
+      detached: true,
+      shell: false
+    });
+
+    var err = '';
+
+    proc.stderr.on('data', (data) => {
+      err += data;
+    });
+
+    proc.on('close', (code) => {
+      if (code === 0) resolve();
+      else reject('Program terminated with code ' + code + ':\n' + err);
+    });
+  });
 };

--- a/lib/win.js
+++ b/lib/win.js
@@ -16,21 +16,24 @@ exports.set = imagePath => {
 		return Promise.reject(new TypeError('Expected a string'));
 	}
 
-  return new Promise((resolve, reject) => {
-    var proc = spawn(bin, [path.resolve(imagePath)], {
+	return new Promise((resolve, reject) => {
+    let proc = spawn(bin, [path.resolve(imagePath)], {
       detached: true,
       shell: false
     });
 
-    var err = '';
+    let err = '';
 
-    proc.stderr.on('data', (data) => {
+    proc.stderr.on('data', data => {
       err += data;
     });
 
-    proc.on('close', (code) => {
-      if (code === 0) resolve();
-      else reject('Program terminated with code ' + code + ':\n' + err);
+    proc.on('close', code => {
+      if (code === 0) {
+				resolve();
+			} else {
+				reject(new Error('Program terminated with code ' + code + ':\n' + err));
+			}
     });
   });
 };

--- a/lib/win.js
+++ b/lib/win.js
@@ -17,23 +17,23 @@ exports.set = imagePath => {
 	}
 
 	return new Promise((resolve, reject) => {
-    let proc = spawn(bin, [path.resolve(imagePath)], {
-      detached: true,
-      shell: false
-    });
+		let proc = spawn(bin, [path.resolve(imagePath)], {
+			detached: true,
+			shell: false
+		});
 
-    let err = '';
+		let err = '';
 
-    proc.stderr.on('data', data => {
-      err += data;
-    });
+		proc.stderr.on('data', data => {
+			err += data;
+		});
 
-    proc.on('close', code => {
-      if (code === 0) {
+		proc.on('close', code => {
+			if (code === 0) {
 				resolve();
 			} else {
 				reject(new Error('Program terminated with code ' + code + ':\n' + err));
 			}
-    });
-  });
+		});
+	});
 };

--- a/lib/win.js
+++ b/lib/win.js
@@ -18,8 +18,7 @@ exports.set = imagePath => {
 
 	return new Promise((resolve, reject) => {
 		const proc = spawn(bin, [path.resolve(imagePath)], {
-			detached: true,
-			shell: false
+			detached: true
 		});
 
 		let err = '';


### PR DESCRIPTION
**Context:**
I made a script that update my wallpaper every 10 minutes, and used [forever](https://www.npmjs.com/package/forever) to run it as a daemon.

**Problem:**
Every time it set the wallpaper on windows there is a shell that pop for 0.5 sec and it's quite annoying, especially while playing games or watching movies.

**Solution:**
Use childrenProcess.spawn to set the wallpaper with detached at true and shell at false to prevent the opening of a shell.