### PR TITLE
Add suppport for KDE/Plasma

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -66,7 +66,7 @@ const appsList = [
 		]
 	},
 	{
-		cmd: 'dconf',
+		cmd: 'adconf',
 		set: ['write',
 			'/org/mate/desktop/background/picture-filename',
 			'"%s"'
@@ -75,6 +75,14 @@ const appsList = [
 			'/org/mate/desktop/background/picture-filename'
 		],
 		transform: imagePath => imagePath.slice(1, -1)
+	},
+		{
+		cmd: 'qdbus',
+		set: ['org.kde.plasmashell',
+			'/PlasmaShell',
+			'org.kde.PlasmaShell.evaluateScript',
+			'var allDesktops = desktops();print (allDesktops);for (i=0;i<allDesktops.length;i++) {d = allDesktops[i];d.wallpaperPlugin = \"org.kde.image\";d.currentConfigGroup = Array(\"Wallpaper\", \"org.kde.image\", \"General\");d.writeConfig(\"Image\", \"file:\/\/%s\")}'
+		]
 	}
 ];
 

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -66,7 +66,7 @@ const appsList = [
 		]
 	},
 	{
-		cmd: 'adconf',
+		cmd: 'dconf',
 		set: ['write',
 			'/org/mate/desktop/background/picture-filename',
 			'"%s"'

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -76,7 +76,7 @@ const appsList = [
 		],
 		transform: imagePath => imagePath.slice(1, -1)
 	},
-		{
+	{
 		cmd: 'qdbus',
 		set: ['org.kde.plasmashell',
 			'/PlasmaShell',

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -81,7 +81,7 @@ const appsList = [
 		set: ['org.kde.plasmashell',
 			'/PlasmaShell',
 			'org.kde.PlasmaShell.evaluateScript',
-			'var allDesktops = desktops();print (allDesktops);for (i=0;i<allDesktops.length;i++) {d = allDesktops[i];d.wallpaperPlugin = \"org.kde.image\";d.currentConfigGroup = Array(\"Wallpaper\", \"org.kde.image\", \"General\");d.writeConfig(\"Image\", \"file:\/\/%s\")}'
+			'var allDesktops = desktops();print (allDesktops);for (i=0;i<allDesktops.length;i++) {d = allDesktops[i];d.wallpaperPlugin = "org.kde.image";d.currentConfigGroup = Array("Wallpaper", "org.kde.image", "General");d.writeConfig("Image", "file://%s")}'
 		]
 	}
 ];

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -81,7 +81,12 @@ const appsList = [
 		set: ['org.kde.plasmashell',
 			'/PlasmaShell',
 			'org.kde.PlasmaShell.evaluateScript',
-			'var allDesktops = desktops();print (allDesktops);for (i=0;i<allDesktops.length;i++) {d = allDesktops[i];d.wallpaperPlugin = "org.kde.image";d.currentConfigGroup = Array("Wallpaper", "org.kde.image", "General");d.writeConfig("Image", "file://%s")}'
+			`var allDesktops = desktops();
+			for (i=0;i<allDesktops.length;i++) {
+				d = allDesktops[i];
+				d.wallpaperPlugin = "org.kde.image";d.currentConfigGroup = Array("Wallpaper", "org.kde.image", "General");
+				d.writeConfig("Image", "file://%s")
+			}`
 		]
 	}
 ];

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -81,12 +81,15 @@ const appsList = [
 		set: ['org.kde.plasmashell',
 			'/PlasmaShell',
 			'org.kde.PlasmaShell.evaluateScript',
-			`var allDesktops = desktops();
-			for (i=0;i<allDesktops.length;i++) {
-				d = allDesktops[i];
-				d.wallpaperPlugin = "org.kde.image";d.currentConfigGroup = Array("Wallpaper", "org.kde.image", "General");
-				d.writeConfig("Image", "file://%s")
-			}`
+			`
+				var allDesktops = desktops();
+				for (var i = 0; i < allDesktops.length; i++) {
+					var desktop = allDesktops[i];
+					desktop.wallpaperPlugin = 'org.kde.image';
+					desktop.currentConfigGroup = ['Wallpaper', 'org.kde.image', 'General'];
+					desktop.writeConfig('Image', 'file://%s');
+				}
+			`
 		]
 	}
 ];


### PR DESCRIPTION
On my linux system with Plasma (running Arch Linux/Manjaro) this tool does not work since neither gsettings nor gconftool-2 nor dcop work even though they are present.

This PR adds a working method using qdbus.

Without #27 or similar this does not really help as the other ones (gsettings ...) are present and used first.
As a workaround I just manually delete all other services from the lib/linux.js script for now.