### PR TITLE
Fix run command on Linux

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -124,7 +124,7 @@ function setAvailableApps() {
 	// `which` all commands and expect stdout to return a positive
 	const whichCmd = `which -a ${names.join('; which -a ')}`;
 
-	return cp.exec(whichCmd).then(stdout => {
+	return cp.exec(`echo $(${whichCmd})`).then(stdout => {
 		stdout = stdout.trim();
 
 		if (!stdout) {


### PR DESCRIPTION
 Error log

```
{ Error: Command failed: which -a gsettings; which -a setroot; which -a pcmanfm; which -a feh; which -a nitrogen; which -a xfconf-query; which -a gconftool-2; which -a dcop; which -a dconf; which -a qdbus
which: no setroot in (/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/var/lib/snapd/snap/bin)
which: no pcmanfm in (/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/var/lib/snapd/snap/bin)
which: no nitrogen in (/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/var/lib/snapd/snap/bin)
which: no dcop in (/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/var/lib/snapd/snap/bin)
which: no qdbus in (/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/var/lib/snapd/snap/bin)

    at ChildProcess.exithandler (child_process.js:272:12)
    at ChildProcess.emit (events.js:160:13)
    at maybeClose (internal/child_process.js:943:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:220:5)
  killed: false,
  code: 1,
  signal: null,
  cmd: 'which -a gsettings; which -a setroot; which -a pcmanfm; which -a feh; which -a nitrogen; which -a xfconf-query; which -a gconftool-2; which -a dcop; which -a dconf; which -a qdbus' }
```

# Summary

Command `which` return `code: 1; signal: mull` when a binary is not found.

NOTE: The same error has in the Windows OS (#3, #26, #29)

# Solution
Run the command with `echo`