### PR TITLE
Ubuntu 16.04 - Line break

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -135,6 +135,11 @@ function setAvailableApps() {
 		// and only the executable name. i.e. 'foo' from /bin/foo
 		stdout = stdout.split('\n');
 
+		// If the string does not have line breaks
+		if (stdout.length === 1) {
+			stdout = stdout[0].split(' ');
+		}
+
 		stdout.forEach(el => {
 			// It's an alias
 			if (el[0] !== path.sep) {
@@ -153,7 +158,7 @@ function isCinnamon() {
 
 	return cp.execFile('gsettings', args)
 		.then(out => out.trim() === 'true')
-		.catch(() => {});
+		.catch(() => { });
 }
 
 function isMATE() {
@@ -161,7 +166,7 @@ function isMATE() {
 
 	return cp.execFile('gsettings', args)
 		.then(out => out.trim() === 'true')
-		.catch(() => {});
+		.catch(() => { });
 }
 
 exports.get = function get() {


### PR DESCRIPTION
When I run the get wallpaper function, I get the following error.
(node:9005) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'cmd' of undefined

When I execute the set function, I get the following error: 
![image](https://user-images.githubusercontent.com/20784993/45298397-bf4c7b00-b4de-11e8-9de9-76782536c45c.png)

then I started debugging.
When I run the test I get the following error:
![image](https://user-images.githubusercontent.com/20784993/45299533-4ea75d80-b4e2-11e8-95f2-950ace04f648.png)

The error was in that it did not have applications available in the array, because the string of the cmd did not have line breaks.
