### PR TITLE
fix cmd undefined error

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -124,7 +124,7 @@ function setAvailableApps() {
 	// `which` all commands and expect stdout to return a positive
 	const whichCmd = `which -a ${names.join('; which -a ')}`;
 
-	return cp.exec(`echo $(${whichCmd})`).then(stdout => {
+	return cp.exec(whichCmd).then(stdout => {
 		stdout = stdout.trim();
 
 		if (!stdout) {


### PR DESCRIPTION
Fix ERROR: TypeError: Cannot read property 'cmd' of undefined
at get (.../linux.js:174:10)

value of 'stdout' at line 127 before edit:
`/usr/bin/gsettings /usr/bin/gconftool-2 /usr/bin/dconf /usr/bin/qdbus\n`

value of 'stdout' at line 127 after edit:
```
/usr/bin/gsettings\n
/usr/bin/gconftool-2\n
/usr/bin/dconf\n
/usr/bin/qdbus\n
```

============================================================

value of 'stdout' at line 136 before edit:
`[ '/usr/bin/gsettings /usr/bin/gconftool-2 /usr/bin/dconf /usr/bin/qdbus' ]`

value of 'stdout' at line 136 after edit:
```
[
 '/usr/bin/gsettings',
  '/usr/bin/gconftool-2',
  '/usr/bin/dconf',
  '/usr/bin/qdbus' 
]
```