### PR TITLE
improve mate and cinnamon detection

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -150,16 +150,22 @@ async function setAvailableApps() {
 
 function isSessionActive(session) {
     try {
-        const current_session = process.env.DESKTOP_SESSION.trim();
-        return current_session === session;
-    } catch (_) { return undefined; }
+        const currentSession = process.env.DESKTOP_SESSION.trim();
+		
+        return currentSession === session;
+    } catch (_) {
+		return undefined;
+	}
 }
 
 async function isCinnamon() {
 	const args = ['writable', 'org.cinnamon.desktop.background', 'picture-uri'];
 
 	const isActive = isSessionActive('cinnamon');
-    	if (isActive != undefined) { return isActive; }
+	
+	if (isActive !== undefined) {
+		return isActive;
+	}
 	
 	try {
 		const {stdout} = await execFile('gsettings', args);
@@ -171,10 +177,10 @@ async function isMATE() {
 	const args = ['writable', 'org.mate.background', 'picture-filename'];
 	
 	const isActive = isSessionActive('mate');
-    	if (isActive != undefined) { return isActive; }
-
-	const session = await getCurrentDesktopSession();
-    	if (session) return session === 'mate';
+	
+	if (isActive !== undefined) {
+		return isActive;
+	}
 	
 	try {
 		const {stdout} = await execFile('gsettings', args);

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -148,9 +148,20 @@ async function setAvailableApps() {
 	}
 }
 
+// get the current active desktop session
+async function getCurrentDesktopSession() {
+    try {
+        const {stdout} = await exec('echo $DESKTOP_SESSION');
+        if (stdout.trim() !== '') return stdout.trim();
+    } catch (_) { return undefined; }
+}
+
 async function isCinnamon() {
 	const args = ['writable', 'org.cinnamon.desktop.background', 'picture-uri'];
 
+	const session = await getCurrentDesktopSession();
+    	if (session) return session === 'cinnamon';
+	
 	try {
 		const {stdout} = await execFile('gsettings', args);
 		return stdout.trim() === 'true';
@@ -160,6 +171,9 @@ async function isCinnamon() {
 async function isMATE() {
 	const args = ['writable', 'org.mate.background', 'picture-filename'];
 
+	const session = await getCurrentDesktopSession();
+    	if (session) return session === 'mate';
+	
 	try {
 		const {stdout} = await execFile('gsettings', args);
 		return stdout.trim() === 'true';

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -148,19 +148,18 @@ async function setAvailableApps() {
 	}
 }
 
-// Get the current active desktop session
-async function getCurrentDesktopSession() {
+function isSessionActive(session) {
     try {
-        const {stdout} = await exec('echo $DESKTOP_SESSION');
-        if (stdout.trim() !== '') return stdout.trim();
+        const current_session = process.env.DESKTOP_SESSION.trim();
+        return current_session === session;
     } catch (_) { return undefined; }
 }
 
 async function isCinnamon() {
 	const args = ['writable', 'org.cinnamon.desktop.background', 'picture-uri'];
 
-	const session = await getCurrentDesktopSession();
-    	if (session) return session === 'cinnamon';
+	const isActive = isSessionActive('cinnamon');
+    	if (isActive != undefined) { return isActive; }
 	
 	try {
 		const {stdout} = await execFile('gsettings', args);
@@ -170,6 +169,9 @@ async function isCinnamon() {
 
 async function isMATE() {
 	const args = ['writable', 'org.mate.background', 'picture-filename'];
+	
+	const isActive = isSessionActive('mate');
+    	if (isActive != undefined) { return isActive; }
 
 	const session = await getCurrentDesktopSession();
     	if (session) return session === 'mate';

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -148,7 +148,7 @@ async function setAvailableApps() {
 	}
 }
 
-// get the current active desktop session
+// Get the current active desktop session
 async function getCurrentDesktopSession() {
     try {
         const {stdout} = await exec('echo $DESKTOP_SESSION');


### PR DESCRIPTION
- tested on linux mint 18.3 (cinnamon desktop)

- I have mate and cinnamon desktops installed on my linux mint 18.3 and the __active__ one is `cinnamon` but the code detect that `mate` is the activated one, so the code set the wallpaper on mate not cinnamon

- the function `isSessionActive(session_name)` will check if the session is active