### PR TITLE
Force linux command to have exit code 0

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -123,7 +123,7 @@ async function setAvailableApps() {
 	});
 
 	// `which` all commands and expect stdout to return a positive
-	const whichCmd = `which -a ${names.join('; which -a ')}`;
+	const whichCmd = `which -a ${names.join('; which -a ')}; echo`;
 
 	let {stdout} = await exec(whichCmd);
 	stdout = stdout.trim();


### PR DESCRIPTION
I didn't wanna make more [linux related issues](https://github.com/sindresorhus/wallpaper/issues/42) so I found a fix for https://github.com/sindresorhus/wallpaper-cli/issues/7.

I found that the error was thrown by `child_process` because the exit code of the command was 1 (even tho it's kind of intended). I forced it to have exit code 0 with `echo`, although it's not the most elegant solution. I'm open to other solutions.