### PR TITLE
I fixed the bug with the execution of 'whichCMD' command in lib/linux.js

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -125,27 +125,30 @@ async function setAvailableApps() {
 	// `which` all commands and expect stdout to return a positive
 	const whichCmd = `which -a ${names.join('; which -a ')}`;
 
-	let {stdout} = await exec(whichCmd);
-	stdout = stdout.trim();
+	await new Promise(resolve => {
+		exec(whichCmd, (err, stdout, stderr) => {
+			if (stderr) {
+				throw new Error('None of the apps were found');
+			} else if (err || stdout) {
+				stdout = stdout.trim();
+				// It may return aliases so we only want the real path
+				// and only the executable name. i.e. 'foo' from /bin/foo
+				const lines = stdout.split('\n');
 
-	if (!stdout) {
-		throw new Error('None of the apps were found');
-	}
+				for (let line of lines) {
+					// It's an alias
+					if (line[0] !== path.sep) {
+						return;
+					}
 
-	// It may return aliases so we only want the real path
-	// and only the executable name. i.e. 'foo' from /bin/foo
-	const lines = stdout.split('\n');
+					line = line.split(path.sep).pop();
 
-	for (let line of lines) {
-		// It's an alias
-		if (line[0] !== path.sep) {
-			return;
-		}
-
-		line = line.split(path.sep).pop();
-
-		availableApps.push(availableAppsDict[line]);
-	}
+					availableApps.push(availableAppsDict[line]);
+				}
+				resolve();
+			}
+		});
+	});
 }
 
 async function isCinnamon() {
@@ -154,7 +157,7 @@ async function isCinnamon() {
 	try {
 		const {stdout} = await execFile('gsettings', args);
 		return stdout.trim() === 'true';
-	} catch (_) {}
+	} catch (_) { }
 }
 
 async function isMATE() {
@@ -163,7 +166,7 @@ async function isMATE() {
 	try {
 		const {stdout} = await execFile('gsettings', args);
 		return stdout.trim() === 'true';
-	} catch (_) {}
+	} catch (_) { }
 }
 
 exports.get = async function get() {
@@ -206,7 +209,6 @@ exports.set = async function set(imagePath) {
 	if (typeof imagePath !== 'string') {
 		throw new TypeError('Expected a string');
 	}
-
 	if (!availableApps) {
 		await setAvailableApps();
 		await set(imagePath);
@@ -227,6 +229,5 @@ exports.set = async function set(imagePath) {
 			params.splice(1, 3, 'org.mate.background', 'picture-filename', params[3].replace(/^file:\/\//, ''));
 		}
 	}
-
 	await execFile(app.cmd, params);
 };

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -128,7 +128,7 @@ async function setAvailableApps() {
 	await new Promise(resolve => {
 		exec(whichCmd, (err, stdout, stderr) => {
 			if (stderr) {
-				throw new Error('None of the apps were found');
+				throw new Error(`None of the apps were found. This is the stderr: ${stderr}`);
 			} else if (err || stdout) {
 				stdout = stdout.trim();
 				// It may return aliases so we only want the real path


### PR DESCRIPTION
**Node Version** : v10.14.1
**OS** : Ubuntu 18.04.1 LTS
**Desktop Environment** : GNOME Shell 3.28.3 

When I fork the repo the script lib/linux.js on Ubuntu with Gnome crashed. 
So I debug the script and I understand that the _whichCMD_ command works, but it crashes because the _exec_ function responds with an _err_ variable. I don't know the reason why there are errors in this variable because if you run the _whichCMD_ on bash it works and the _stderr_ it's empty. Only the _err_ is an Error object that says 'Command-Failed'.So I fixed this bug checking only if there is something inside _stderr_ and if there are this means that there is an error and I throw the error. If _err_ or _stdout_ variable is not empty, this means the whichCMD works fine and so we know which desktop environment.