### PR TITLE
Update macos.js

### DIFF
--- a/source/macos.js
+++ b/source/macos.js
@@ -10,7 +10,7 @@ const binary = path.join(__dirname, 'macos-wallpaper');
 
 exports.get = async () => {
 	const {stdout} = await execFile(binary, ['get']);
-	return stdout.trim();
+	return stdout.trim().match("\n") ? stdout.trim().split("\n") : stdout.trim();
 };
 
 exports.set = async (imagePath, options) => {

--- a/source/macos.js
+++ b/source/macos.js
@@ -10,7 +10,7 @@ const binary = path.join(__dirname, 'macos-wallpaper');
 
 exports.get = async () => {
 	const {stdout} = await execFile(binary, ['get']);
-	return stdout.trim().match("\n") ? stdout.trim().split("\n") : stdout.trim();
+	return stdout.trim().match('\n') ? stdout.trim().split('\n') : stdout.trim();
 };
 
 exports.set = async (imagePath, options) => {


### PR DESCRIPTION
Return an array of path if stdout return multiple path(multiple screen).

Because it's annoying to process string in case of dual/multiple screen.