### PR TITLE
Fix Arch and Kubuntu compatibility

### DIFF
--- a/source/linux/background-managers/index.js
+++ b/source/linux/background-managers/index.js
@@ -10,6 +10,7 @@ module.exports = {
 	mate: require('./mate'),
 	nitrogen: require('./nitrogen'),
 	pcmanfm: require('./pcmanfm'),
+	qdbus: require('./qdbus'),
 	setroot: require('./setroot'),
 	xfconfquery: require('./xfconf-query')
 };


### PR DESCRIPTION
@sindresorhus looks like qdbus was just unused. I tested this in Kubuntu and it worked. Just an oversight? Git blame shows it was just not there when it was re-written in sindresorhus#43

Added above setroot arbitrarily since that is the order its in alphabetically.

Fixes #70